### PR TITLE
알고리즘 자동화 오류와 한국시간 예약 설정 수정

### DIFF
--- a/.github/workflows/daily-algorithm.yml
+++ b/.github/workflows/daily-algorithm.yml
@@ -2,8 +2,10 @@ name: 오늘의 알고리즘 문제
 
 on:
   schedule:
-    # 정각의 GitHub Actions 예약 실행 혼잡을 피해 월~금 00:07 UTC = 09:07 KST
-    - cron: "7 0 * * 1-5"
+    # GitHub Actions의 기본 UTC 해석에 기대지 않고 한국시간을 명시합니다.
+    # 정각 혼잡을 피해 월~금 오전 09:07에 실행을 요청합니다.
+    - cron: "7 9 * * 1-5"
+      timezone: "Asia/Seoul"
   workflow_dispatch:
     inputs:
       study_date:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ GitHub에서 `base repository`는 `YEOUL0520/ALGO_GUMI_5_16th`, `base`는 `main`
 ## 관리자 운영
 
 - 자동 출제: 월요일~금요일 09:07 KST
+- 워크플로에 `Asia/Seoul` 시간대를 명시해 UTC 변환 오류를 방지합니다.
+- GitHub Actions 예약 실행은 서비스 혼잡 시 지연될 수 있습니다.
 - 일정 입력 권장 시각: 전날 23:59 이전
 - 수동 실행: `Actions → 오늘의 알고리즘 문제 → Run workflow`
 - 수동 실행 시 `study_date`에 `YYYY-MM-DD`를 넣어 특정 날짜를 테스트할 수 있습니다.

--- a/data/algorithm-problems.json
+++ b/data/algorithm-problems.json
@@ -42,12 +42,12 @@
       "difficulty": "D5",
       "url": "https://swexpertacademy.com/main/code/problem/problemDetail.do?problemLevel=5&contestProbId=AV18R8FKIvoCFAZN&categoryId=AV18R8FKIvoCFAZN&categoryType=CODE&problemTitle=&orderBy=RECOMMEND_COUNT&selectCodeLang=JAVA&select-1=5&pageSize=10&pageIndex=1&&&&&&&&&&"
     },
-{
+    {
       "number": "1812",
       "title": "수정이의 타일 자르기",
       "difficulty": "D5",
       "url": "https://swexpertacademy.com/main/code/problem/problemDetail.do?problemLevel=5&contestProbId=AV4yGVsKC0YDFAUx&categoryId=AV4yGVsKC0YDFAUx&categoryType=CODE&problemTitle=&orderBy=RECOMMEND_COUNT&selectCodeLang=JAVA&select-1=5&pageSize=10&pageIndex=1"
-    },
+    }
   ],
   "medium": [
     {


### PR DESCRIPTION
## 변경 사항

- `algorithm-problems.json`의 마지막 `high` 항목 뒤에 있던 불필요한 쉼표를 제거했습니다.
- 예약 워크플로에 `timezone: Asia/Seoul`을 명시하고 평일 09:07 KST로 설정했습니다.
- README에 한국시간 설정과 GitHub Actions 예약 지연 가능성을 기록했습니다.

## 원인

2026-07-31 실패한 `알고리즘 자동화 검증`은 문제 은행 JSON의 trailing comma 때문에 `JSON.parse`가 `Unexpected token ']'` 오류를 낸 것이 원인이었습니다.

알림 시각은 UTC 변환 자체는 맞았지만, 최근 예약 실행이 약 3시간 지연되어 12시대에 시작됐습니다. GitHub Actions 예약 실행은 서비스 혼잡 시 지연될 수 있으므로, 시간대 해석의 모호함을 없애기 위해 한국시간을 워크플로에 직접 명시했습니다.

## 검증

- `node scripts/test-automation.mjs` 통과 (문제 은행 23개)
- `algorithm-problems.json` 직접 JSON 파싱 통과
- `git diff --check` 통과

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data and CI scheduling fixes with no auth or runtime logic changes; only restores parseable JSON and clarifies cron timezone.
> 
> **Overview**
> Fixes **daily algorithm automation** failing on invalid JSON in the problem bank and clarifies **when** the scheduled workflow runs.
> 
> The last entry in `data/algorithm-problems.json` under `high` had a trailing comma before the closing `]`, which caused `JSON.parse` to fail during `알고리즘 자동화 검증`. That comma is removed and the surrounding object indentation is normalized.
> 
> The **오늘의 알고리즘 문제** workflow no longer relies on implicit UTC for the cron schedule. It now uses `cron: "7 9 * * 1-5"` with `timezone: "Asia/Seoul"` so weekday runs are requested at **09:07 KST** (still offset from the hour to reduce Actions queue congestion).
> 
> README **관리자 운영** notes the explicit `Asia/Seoul` setting and that scheduled Actions runs can be delayed when the service is busy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77ad9f1570cc0353a7fec9f01852dea02c25d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->